### PR TITLE
Add OpenAssetIO v1.0.0-alpha.7

### DIFF
--- a/recipes/openassetio/all/conandata.yml
+++ b/recipes/openassetio/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0-alpha.7":
+    url: "https://github.com/OpenAssetIO/OpenAssetIO/archive/v1.0.0-alpha.7.tar.gz"
+    sha256: "afb596df340ae45f79337941068b06f53af42dd7a9321b1dd0010a818833107b"

--- a/recipes/openassetio/all/conanfile.py
+++ b/recipes/openassetio/all/conanfile.py
@@ -1,0 +1,163 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.files import apply_conandata_patches, get, copy, rm
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class PackageConan(ConanFile):
+    name = "openassetio"
+    description = "An open-source interoperability standard for tools and content management systems used in media production."
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/OpenAssetIO/OpenAssetIO"
+    topics = ("asset-pipeline", "vfx", "cg", "assetmanager", "vfx-pipeline")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "without_python": [True, False],
+        "python_version": ["3.7.12", "3.8.12", "3.9.7", "3.10.0"]
+    }
+    default_options = {
+        "shared": False,
+        "without_python": False,
+        "python_version": "3.9.7"
+    }
+    short_paths = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "9",
+            "clang": "10",
+            "apple-clang": "12",
+        }
+
+    def configure(self):
+        if self.options.without_python:
+            self.options.rm_safe("python_version")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if not self.options.without_python:
+            self.requires(f"cpython/{self.options.python_version}")
+            self.requires("pybind11/2.10.0")
+
+    def validate(self):
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        check_min_vs(self, 191)
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+            if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
+
+    def build_requirements(self):
+        self.tool_requires("tomlplusplus/3.2.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+
+        tc.variables["OPENASSETIO_ENABLE_TESTS"] = not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
+
+        libcxx = self.settings.get_safe("compiler.libcxx")
+        if libcxx is not None:
+            if libcxx == "libstdc++11":
+                tc.variables["OPENASSETIO_GLIBCXX_USE_CXX11_ABI"] = True
+            else:
+                tc.variables["OPENASSETIO_GLIBCXX_USE_CXX11_ABI"] = False
+
+        if self.options.without_python:
+            tc.variables["OPENASSETIO_ENABLE_PYTHON"] = False
+        else:
+            tc.variables["OPENASSETIO_ENABLE_PYTHON"] = True
+            tc.variables["Python_EXECUTABLE"] = self._python_exe
+            if self.settings.os == "Windows":
+                tc.variables["Python_LIBRARY"] = self._python_lib
+
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate(scope="build")
+
+    @property
+    def _python_exe(self):
+        return self.deps_user_info["cpython"].python
+
+    @property
+    def _python_lib(self):
+        return os.path.join(
+            self.dependencies["cpython"].cpp_info.rootpath,
+            self.dependencies["cpython"].cpp_info.components["embed"].libdirs[0],
+            self.dependencies["cpython"].cpp_info.components["embed"].libs[0])
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package_id(self):
+        if not self.options.without_python:
+            self.info.requires["cpython"].minor_mode()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+        rm(self, "OpenAssetIOConfig*.cmake", os.path.join(self.package_folder, "lib", "cmake", "OpenAssetIO"))
+        rm(self, "OpenAssetIOTargets*.cmake", os.path.join(self.package_folder, "lib", "cmake", "OpenAssetIO"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["package_lib"]
+        self.cpp_info.set_property("cmake_file_name", "OpenAssetIO")
+        self.cpp_info.set_property("cmake_target_name", "OpenAssetIO::OpenAssetIO")
+        self.cpp_info.set_property("cmake_build_modules", [os.path.join("lib", "cmake", "OpenAssetIO", "OpenAssetIOVariables.cmake")])
+        self.cpp_info.builddirs = [os.path.join("lib", "cmake")]
+
+        self.cpp_info.components["openassetio-core"].set_property("cmake_target_name", "OpenAssetIO::openassetio-core")
+        self.cpp_info.components["openassetio-core"].libs = ["openassetio"]
+        self.cpp_info.components["openassetio-core-c"].set_property("cmake_target_name", "OpenAssetIO::openassetio-core-c")
+        self.cpp_info.components["openassetio-core-c"].requires = ["openassetio-core"]
+        self.cpp_info.components["openassetio-core-c"].libs = ["openassetio-c"]
+        if not self.options.shared and self._stdcpp_library:
+            self.cpp_info.components["openassetio-core-c"].system_libs.append(self._stdcpp_library)
+        if not self.options.without_python:
+            self.cpp_info.components["openassetio-python-bridge"].set_property("cmake_target_name", "OpenAssetIO::openassetio-python-bridge")
+            self.cpp_info.components["openassetio-python-bridge"].requires = ["openassetio-core"]
+            self.cpp_info.components["openassetio-python-bridge"].libs = ["openassetio-python"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "OpenAssetIO"
+        self.cpp_info.names["cmake_find_package_multi"] = "OpenAssetIO"
+
+    @property
+    def _stdcpp_library(self):
+        libcxx = self.settings.get_safe("compiler.libcxx")
+        if libcxx in ("libstdc++", "libstdc++11"):
+            return "stdc++"
+        elif libcxx in ("libc++",):
+            return "c++"
+        return False

--- a/recipes/openassetio/all/test_package/conandata.yml
+++ b/recipes/openassetio/all/test_package/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0-alpha.7":
+    url: "https://github.com/OpenAssetIO/OpenAssetIO-Test-CMake/archive/1.0.0-alpha.1.tar.gz"
+    sha256: "99f0c3b572fe3e596f298023e830b30b8842e0c01ce1d2f90149fe233202d025"

--- a/recipes/openassetio/all/test_package/conanfile.py
+++ b/recipes/openassetio/all/test_package/conanfile.py
@@ -1,0 +1,71 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
+from conan.tools.files import get
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+        if "without_python" in self.options["openassetio"] and self.options["openassetio"].without_python:
+            python_version = None
+        elif "python_version" in self.options["openassetio"]:
+            python_version = self.options['openassetio'].python_version
+        else:
+            python_version = "3.9.7"
+
+        if python_version is not None:
+            self.requires(f"cpython/{python_version}")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        get(self, **self.conan_data["sources"][self.dependencies["openassetio"].ref.version], destination=self.source_folder, strip_root=True)
+        tc = CMakeToolchain(self)
+
+        libcxx = self.settings.get_safe("compiler.libcxx")
+        if libcxx is not None:
+            if libcxx == "libstdc++11":
+                tc.variables["OPENASSETIOTEST_GLIBCXX_USE_CXX11_ABI"] = True
+            else:
+                tc.variables["OPENASSETIOTEST_GLIBCXX_USE_CXX11_ABI"] = False
+
+        if self.dependencies["openassetio"].options.without_python:
+            tc.variables["OPENASSETIOTEST_ENABLE_PYTHON"] = False
+        else:
+            tc.variables["OPENASSETIOTEST_ENABLE_PYTHON"] = True
+            tc.variables["Python_EXECUTABLE"] = self._python_exe
+            if self.settings.os == "Windows":
+                tc.variables["Python_LIBRARY"] = self._python_lib
+
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmake = CMake(self)
+            cmake.test()
+
+    @property
+    def _python_exe(self):
+        return self.deps_user_info["cpython"].python
+
+    @property
+    def _python_lib(self):
+        return os.path.join(
+            self.dependencies["cpython"].cpp_info.rootpath,
+            self.dependencies["cpython"].cpp_info.components["embed"].libdirs[0],
+            self.dependencies["cpython"].cpp_info.components["embed"].libs[0])

--- a/recipes/openassetio/all/test_v1_package/conandata.yml
+++ b/recipes/openassetio/all/test_v1_package/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0-alpha.7":
+    url: "https://github.com/OpenAssetIO/OpenAssetIO-Test-CMake/archive/1.0.0-alpha.1.tar.gz"
+    sha256: "99f0c3b572fe3e596f298023e830b30b8842e0c01ce1d2f90149fe233202d025"

--- a/recipes/openassetio/all/test_v1_package/conanfile.py
+++ b/recipes/openassetio/all/test_v1_package/conanfile.py
@@ -1,0 +1,71 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
+from conan.tools.files import get
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+        if "without_python" in self.options["openassetio"] and self.options["openassetio"].without_python:
+            python_version = None
+        elif "python_version" in self.options["openassetio"]:
+            python_version = self.options['openassetio'].python_version
+        else:
+            python_version = "3.9.7"
+
+        if python_version is not None:
+            self.requires(f"cpython/{python_version}")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        get(self, **self.conan_data["sources"][self.dependencies["openassetio"].ref.version], destination=self.source_folder, strip_root=True)
+        tc = CMakeToolchain(self)
+
+        libcxx = self.settings.get_safe("compiler.libcxx")
+        if libcxx is not None:
+            if libcxx == "libstdc++11":
+                tc.variables["OPENASSETIOTEST_GLIBCXX_USE_CXX11_ABI"] = True
+            else:
+                tc.variables["OPENASSETIOTEST_GLIBCXX_USE_CXX11_ABI"] = False
+
+        if self.dependencies["openassetio"].options.without_python:
+            tc.variables["OPENASSETIOTEST_ENABLE_PYTHON"] = False
+        else:
+            tc.variables["OPENASSETIOTEST_ENABLE_PYTHON"] = True
+            tc.variables["Python_EXECUTABLE"] = self._python_exe
+            if self.settings.os == "Windows":
+                tc.variables["Python_LIBRARY"] = self._python_lib
+
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmake = CMake(self)
+            cmake.test()
+
+    @property
+    def _python_exe(self):
+        return self.deps_user_info["cpython"].python
+
+    @property
+    def _python_lib(self):
+        return os.path.join(
+            self.dependencies["cpython"].cpp_info.rootpath,
+            self.dependencies["cpython"].cpp_info.components["embed"].libdirs[0],
+            self.dependencies["cpython"].cpp_info.components["embed"].libs[0])

--- a/recipes/openassetio/config.yml
+++ b/recipes/openassetio/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0-alpha.7":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **OpenAssetIO/1.0.0-alpha.7**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

OpenAssetIO is a C++ library with C and Python bindings. It has a plugin system allowing so-called "manager" plugins to be loaded into a "host" application.  Hosts and plugins can be written in C++, C or Python, with OpenAssetIO marshalling between languages as necessary.

The goal is to provide a common interface for host applications to communicate with a central asset management system - a common pattern in the VFX industry.

It is an ASWF project, much like OpenColorIO, OpenEXR, OpenVDB, ..., which are also represented in ConanCenter. I am one of the maintainers of OpenAssetIO, funded by The Foundry.

OpenAssetIO is currently undergoing development and is still in the alpha stage.  We would like a ConanCenter package to give us and early adopters an easy way to begin to migrate applications/tools and flag any pain points as early as possible.

The Conan recipe has a few uncommon features:

The `fPIC` option is not supported.  Since one of the build artifacts is a Python extension module, which must be a shared library and must link to the core C++ library, we must always enable PIC for the core library.

The `cpython` package is used as a dependency. It's surprising how few (none, apparently) recipes make use of the `cpython` Conan package. The `cpython` package is not currently Conan v2 friendly, so we must use, for example, the deprecated `deps_user_info`.

The C bindings, if built as a static library, must be told to link to the C++ standard library. The way Conan's CMake generators work (`IMPORTED INTERFACE` rather than `IMPORTED STATIC`) means that this isn't done automatically. To work around this we take inspiration from  conan-io#729.

The `test_package` uses an external test repository that exercises basic linkage and imports. This is also used upstream as one of the CI checks.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.


# Review notes

## Source template

The conanfile was customised from a template in https://github.com/conan-io/conan-center-index/tree/master/docs/package_templates/cmake_package

## Testing

```
cd recipes/openassetio/all
conan create . openassetio/1.0.0-alpha.7@
rm -rf test_package/build
```
(note the `rm` line at the end - this is just to ensure no CMake cache shenanigans if building again with different options)

You can test passing options by adding e.g. `-o openassetio:shared=True -o openassetio:without_python=True`